### PR TITLE
Support FF v2 token transfer

### DIFF
--- a/contracts/feralfile-exhibition-v2/feralfile.go
+++ b/contracts/feralfile-exhibition-v2/feralfile.go
@@ -121,7 +121,7 @@ func (c *FeralfileExhibitionV2Contract) Call(wallet *ethereum.Wallet, method, fu
 		t.GasLimit = 120000
 
 		tx, err := contract.SafeTransferFrom(t,
-			t.From, params.To, &params.TokenID.Int)
+			common.HexToAddress(wallet.Account()), params.To, &params.TokenID.Int)
 		if err != nil {
 			return nil, err
 		}

--- a/contracts/feralfile-exhibition-v2/feralfile.go
+++ b/contracts/feralfile-exhibition-v2/feralfile.go
@@ -109,6 +109,23 @@ func (c *FeralfileExhibitionV2Contract) Call(wallet *ethereum.Wallet, method, fu
 			return nil, err
 		}
 		return tx, nil
+	case "transfer":
+		var params struct {
+			To      common.Address  `json:"to"`
+			TokenID ethereum.BigInt `json:"token_id"`
+		}
+		if err := json.Unmarshal(arguments, &params); err != nil {
+			return nil, err
+		}
+
+		t.GasLimit = 120000
+
+		tx, err := contract.SafeTransferFrom(t,
+			t.From, params.To, &params.TokenID.Int)
+		if err != nil {
+			return nil, err
+		}
+		return tx, nil
 	default:
 		return nil, fmt.Errorf("unsupported method")
 	}

--- a/ethereum.go
+++ b/ethereum.go
@@ -144,7 +144,7 @@ func (w *Wallet) SignABIParameters(ctx context.Context, types []string, argument
 }
 
 // TransferETH performs regular ethereum transferring
-func (w *Wallet) TransferETH(ctx context.Context, to string, amount string, customizeGasPrice int64) (string, error) {
+func (w *Wallet) TransferETH(ctx context.Context, to string, amount string, customizeGasPriceInWei int64) (string, error) {
 	account := w.account
 	nonce, err := w.rpcClient.PendingNonceAt(ctx, account.Address)
 	if err != nil {
@@ -162,8 +162,8 @@ func (w *Wallet) TransferETH(ctx context.Context, to string, amount string, cust
 
 	var gasPrice *big.Int
 
-	if customizeGasPrice != 0 {
-		gasPrice = big.NewInt(customizeGasPrice * params.GWei)
+	if customizeGasPriceInWei != 0 {
+		gasPrice = big.NewInt(customizeGasPriceInWei * params.Wei)
 	} else {
 		var err error
 		gasPrice, err = w.rpcClient.SuggestGasPrice(ctx)


### PR DESCRIPTION
Support v2 token transfer by using the safeTransferFrom function in erc721.