### PR TITLE
Fixed estimate gas limit instead by hard code

### DIFF
--- a/contracts.go
+++ b/contracts.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -22,29 +21,21 @@ type Contract interface {
 		fund string,
 		arguments json.RawMessage,
 		noSend bool,
-		customizeGasPriceInWei *int64,
-		customizedNonce *uint64) (tx *types.Transaction, err error)
+		gasLimit uint64,
+		gasPrice *int64,
+		nonce *uint64) (tx *types.Transaction, err error)
 
 	// Pack packs the method and arguments into a byte array representing
 	// the smart contract call data
 	Pack(
-		wallet *Wallet,
 		method string,
 		arguments json.RawMessage) ([]byte, error)
 
 	// Parse parses the arguments as JSON format into an array of smart
 	// contract function call arguments
 	Parse(
-		wallet *Wallet,
 		method string,
 		arguments json.RawMessage) ([]interface{}, error)
-
-	// EstimateGasLimit estimates the gas limit for a smart contract method call
-	EstimateGasLimit(
-		wallet *Wallet,
-		contractAddr common.Address,
-		method string,
-		arguments json.RawMessage) (uint64, error)
 }
 
 // ContractFactory is a function that takes an address and return a Contract instance

--- a/contracts.go
+++ b/contracts.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -27,14 +28,23 @@ type Contract interface {
 	// Pack packs the method and arguments into a byte array representing
 	// the smart contract call data
 	Pack(
+		wallet *Wallet,
 		method string,
 		arguments json.RawMessage) ([]byte, error)
 
 	// Parse parses the arguments as JSON format into an array of smart
 	// contract function call arguments
 	Parse(
+		wallet *Wallet,
 		method string,
 		arguments json.RawMessage) ([]interface{}, error)
+
+	// EstimateGasLimit estimates the gas limit for a smart contract method call
+	EstimateGasLimit(
+		wallet *Wallet,
+		contractAddr common.Address,
+		method string,
+		arguments json.RawMessage) (uint64, error)
 }
 
 // ContractFactory is a function that takes an address and return a Contract instance

--- a/contracts/feralfile-english-auction/english_auction.go
+++ b/contracts/feralfile-english-auction/english_auction.go
@@ -1,7 +1,6 @@
 package english_auction
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -10,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	goEthereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -60,8 +58,9 @@ func (c *FeralfileEnglishAuctionContract) Call(
 	fund string,
 	arguments json.RawMessage,
 	noSend bool,
-	customizeGasPriceInWei *int64,
-	customizedNonce *uint64) (*types.Transaction, error) {
+	gasLimit uint64,
+	gasPrice *int64,
+	nonce *uint64) (*types.Transaction, error) {
 	contractAddr := common.HexToAddress(c.contractAddress)
 	contract, err := english_auction.NewFeralfileEnglishAuction(contractAddr, wallet.RPCClient())
 	if err != nil {
@@ -73,15 +72,16 @@ func (c *FeralfileEnglishAuctionContract) Call(
 	}
 
 	t.NoSend = noSend
-	if customizeGasPriceInWei != nil && *customizeGasPriceInWei != 0 {
-		t.GasPrice = big.NewInt(*customizeGasPriceInWei * params.Wei)
+	t.GasLimit = gasLimit
+	if gasPrice != nil && *gasPrice != 0 {
+		t.GasPrice = big.NewInt(*gasPrice * params.Wei)
 	}
 
-	if customizedNonce != nil {
-		t.Nonce = big.NewInt(int64(*customizedNonce))
+	if nonce != nil {
+		t.Nonce = big.NewInt(int64(*nonce))
 	}
 
-	params, err := c.Parse(wallet, method, arguments)
+	params, err := c.Parse(method, arguments)
 	if nil != err {
 		return nil, err
 	}
@@ -96,13 +96,6 @@ func (c *FeralfileEnglishAuctionContract) Call(
 		if !ok {
 			return nil, fmt.Errorf("invalid auctions params")
 		}
-
-		gasLimit, err := c.EstimateGasLimit(wallet, contractAddr, method, arguments)
-		if nil != err {
-			return nil, err
-		}
-
-		t.GasLimit = gasLimit
 
 		return contract.RegisterAuctions(t, auctions)
 	case "placeSignedBid":
@@ -213,7 +206,6 @@ func (c *FeralfileEnglishAuctionContract) Call(
 }
 
 func (c *FeralfileEnglishAuctionContract) Pack(
-	wallet *ethereum.Wallet,
 	method string,
 	arguments json.RawMessage) ([]byte, error) {
 	abi, err := english_auction.FeralfileEnglishAuctionMetaData.GetAbi()
@@ -221,7 +213,7 @@ func (c *FeralfileEnglishAuctionContract) Pack(
 		return nil, err
 	}
 
-	parsedArgs, err := c.Parse(wallet, method, arguments)
+	parsedArgs, err := c.Parse(method, arguments)
 	if nil != err {
 		return nil, err
 	}
@@ -230,7 +222,6 @@ func (c *FeralfileEnglishAuctionContract) Pack(
 }
 
 func (c *FeralfileEnglishAuctionContract) Parse(
-	wallet *ethereum.Wallet,
 	method string,
 	arguments json.RawMessage) ([]interface{}, error) {
 	switch method {
@@ -400,29 +391,6 @@ func (c *FeralfileEnglishAuctionContract) Parse(
 	default:
 		return nil, fmt.Errorf("unsupported method")
 	}
-}
-
-func (c *FeralfileEnglishAuctionContract) EstimateGasLimit(
-	wallet *ethereum.Wallet,
-	contractAddr common.Address,
-	method string,
-	arguments json.RawMessage) (uint64, error) {
-	data, err := c.Pack(wallet, method, arguments)
-	if nil != err {
-		return 0, err
-	}
-
-	gas, err := wallet.RPCClient().EstimateGas(context.Background(), goEthereum.CallMsg{
-		From: common.HexToAddress(wallet.Account()),
-		To:   &contractAddr,
-		Data: data,
-	})
-
-	if nil != err {
-		return 0, err
-	}
-
-	return gas * 115 / 100, nil // add 15% buffer
 }
 
 func init() {

--- a/contracts/feralfile-exhibition-v2/feralfile.go
+++ b/contracts/feralfile-exhibition-v2/feralfile.go
@@ -197,12 +197,12 @@ func (c *FeralfileExhibitionV2Contract) Call(
 			return nil, fmt.Errorf("invalid operator params")
 		}
 
-		approve, ok := params[1].(bool)
+		approved, ok := params[1].(bool)
 		if !ok {
-			return nil, fmt.Errorf("invalid approve params")
+			return nil, fmt.Errorf("invalid approved params")
 		}
 
-		return contract.SetApprovalForAll(t, operator, approve)
+		return contract.SetApprovalForAll(t, operator, approved)
 	default:
 		return nil, fmt.Errorf("unsupported method")
 	}
@@ -280,13 +280,13 @@ func (c *FeralfileExhibitionV2Contract) Parse(
 	case "setApprovalForAll":
 		var params struct {
 			Operator common.Address `json:"operator"`
-			Approve  bool           `json:"approve"`
+			Approved bool           `json:"approved"`
 		}
 		if err := json.Unmarshal(arguments, &params); err != nil {
 			return nil, err
 		}
 
-		return []interface{}{params.Operator, params.Approve}, nil
+		return []interface{}{params.Operator, params.Approved}, nil
 	default:
 		return nil, fmt.Errorf("unsupported method")
 	}

--- a/contracts/feralfile-exhibition-v3/feralfile.go
+++ b/contracts/feralfile-exhibition-v3/feralfile.go
@@ -176,12 +176,12 @@ func (c *FeralfileExhibitionV3Contract) Call(
 			return nil, fmt.Errorf("invalid operator params")
 		}
 
-		approve, ok := params[1].(bool)
+		approved, ok := params[1].(bool)
 		if !ok {
-			return nil, fmt.Errorf("invalid approve params")
+			return nil, fmt.Errorf("invalid approved params")
 		}
 
-		return contract.SetApprovalForAll(t, operator, approve)
+		return contract.SetApprovalForAll(t, operator, approved)
 	default:
 		return nil, fmt.Errorf("unsupported method")
 	}
@@ -342,13 +342,13 @@ func (c *FeralfileExhibitionV3Contract) Parse(
 	case "setApprovalForAll":
 		var params struct {
 			Operator common.Address `json:"operator"`
-			Approve  bool           `json:"approve"`
+			Approved bool           `json:"approved"`
 		}
 		if err := json.Unmarshal(arguments, &params); err != nil {
 			return nil, err
 		}
 
-		return []interface{}{params.Operator, params.Approve}, nil
+		return []interface{}{params.Operator, params.Approved}, nil
 	default:
 		return nil, fmt.Errorf("unsupported method")
 	}

--- a/contracts/feralfile-exhibition-v4/feralfile.go
+++ b/contracts/feralfile-exhibition-v4/feralfile.go
@@ -191,12 +191,14 @@ func (c *FeralfileExhibitionV4Contract) Call(
 			return nil, errors.New("Invalid operator")
 		}
 
-		approve, ok := params[1].(bool)
+		approved, ok := params[1].(bool)
 		if !ok {
-			return nil, errors.New("Invalid approve")
+			return nil, errors.New("Invalid approved")
 		}
 
-		return contract.SetApprovalForAll(t, operator, approve)
+		t.GasLimit = gasLimit
+
+		return contract.SetApprovalForAll(t, operator, approved)
 	default:
 		return nil, fmt.Errorf("unsupported method")
 	}
@@ -276,13 +278,13 @@ func (c *FeralfileExhibitionV4Contract) Parse(
 	case "setApprovalForAll":
 		var params struct {
 			Operator common.Address `json:"operator"`
-			Approve  bool           `json:"approve"`
+			Approved bool           `json:"approved"`
 		}
 		if err := json.Unmarshal(arguments, &params); err != nil {
 			return nil, err
 		}
 
-		return []interface{}{params.Operator, params.Approve}, nil
+		return []interface{}{params.Operator, params.Approved}, nil
 	case "buyArtworks":
 		var params struct {
 			SaleData struct {

--- a/contracts/owner-data/ownerdata.go
+++ b/contracts/owner-data/ownerdata.go
@@ -52,7 +52,7 @@ func (c *OwnerDataContract) Call(wallet *ethereum.Wallet, method, fund string, a
 		t.Nonce = big.NewInt(int64(*customizedNonce))
 	}
 
-	params, err := c.Parse(method, arguments)
+	params, err := c.Parse(wallet, method, arguments)
 	if nil != err {
 		return nil, err
 	}
@@ -95,6 +95,7 @@ func (c *OwnerDataContract) Call(wallet *ethereum.Wallet, method, fund string, a
 }
 
 func (c *OwnerDataContract) Pack(
+	wallet *ethereum.Wallet,
 	method string,
 	arguments json.RawMessage) ([]byte, error) {
 	abi, err := ownerdata.OwnerDataMetaData.GetAbi()
@@ -102,7 +103,7 @@ func (c *OwnerDataContract) Pack(
 		return nil, err
 	}
 
-	parsedArgs, err := c.Parse(method, arguments)
+	parsedArgs, err := c.Parse(wallet, method, arguments)
 	if nil != err {
 		return nil, err
 	}
@@ -111,6 +112,7 @@ func (c *OwnerDataContract) Pack(
 }
 
 func (c *OwnerDataContract) Parse(
+	wallet *ethereum.Wallet,
 	method string,
 	arguments json.RawMessage) ([]interface{}, error) {
 	switch method {
@@ -177,6 +179,14 @@ func (c *OwnerDataContract) Parse(
 	default:
 		return nil, fmt.Errorf("unsupported method")
 	}
+}
+
+func (c *OwnerDataContract) EstimateGasLimit(
+	wallet *ethereum.Wallet,
+	contractAddr common.Address,
+	method string,
+	arguments json.RawMessage) (uint64, error) {
+	return 0, errors.New("not implemented")
 }
 
 func init() {


### PR DESCRIPTION
## BREAKING CHANGES
- The `gasLimit` is mandatory when calling method `Call`. 
- Method change for `FeralfileExhibitionV2` contract.
   - `create_artwork` => `createArtwork `
   - `swap_artwork_from_bitmark` => `swapArtworkFromBitmark`
   - `transfer` => `safeTransferFrom`. Require `from` address params. 
   -  `approve_for_all` => `setApprovalForAll`. Require `approve` flag params. 
- Method change for `FeralfileExhibitionV3` contract 
   - `register_artworks` => `createArtworks`
   - `mint_editions` => `batchMint`
   - `authorized_transfer` => `authorizedTransfer`. 
   - `burn_editions` => `burnEditions`
   - `transfer` => `safeTransferFrom`. Require `from` address params. 
   - `approve_for_all` => `setApprovalForAll`. Require `approve` flag params. 
 - Method change for `FeralfileExhibitionV4` contract
   - `approve_for_all` => `setApprovalForAll`. Require `approve` flag params. 